### PR TITLE
Add handling of parent being absent from cache and parent being self

### DIFF
--- a/fixture-importer.js
+++ b/fixture-importer.js
@@ -1,0 +1,7 @@
+const importFresh = require('.');
+
+module.exports = (what) => {
+	return importFresh(what);
+};
+
+module.exports.__filename = __filename;

--- a/fixture-importer.js
+++ b/fixture-importer.js
@@ -1,6 +1,6 @@
 const importFresh = require('.');
 
-module.exports = (what) => {
+module.exports = what => {
 	return importFresh(what);
 };
 

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ module.exports = moduleId => {
 		}
 	}
 
-	// Delete module from cache
-	delete require.cache[filePath];
+	delete require.cache[filePath]; // Delete module from cache
 
-	// Return fresh module
-	return require.cache[parentPath].require(filePath);
+	const parent = require.cache[parentPath]; // If `filePath` and `parentPath` are the same, cache will already be deleted so we won't get a memory leak in next step
+
+	return parent === undefined ? require(filePath) : parent.require(filePath); // In case cache doesn't have parent, fall back to normal require
 };

--- a/test.js
+++ b/test.js
@@ -21,3 +21,20 @@ test('proper parent value', t => {
 	const childModule = require.cache[path.resolve(__dirname, `${id}.js`)];
 	t.is(childModule.parent, module);
 });
+
+test('self import', t => {
+	const id = './fixture-importer';
+	t.notThrows(() => {
+		importFresh(id)(id);
+	});
+});
+
+test('import when parent removed from cache', t => {
+	const id = './fixture-importer';
+	const importer = importFresh(id);
+	t.true(require.cache[importer.__filename] !== undefined);
+	delete require.cache[importer.__filename];
+	t.notThrows(() => {
+		importer(id);
+	});
+});


### PR DESCRIPTION
Fixes #15 

Now falls back to normal require(parent being `import-fresh` then) if actual parent is not in cache.

Also, handles parent being the same as target by changing parent to `import-fresh` too. (I'd suspect it is a really rare edge case, but memory leak from repeated `import-fresh`ing itself would be quite hard to debug.)

//NOTE additionally tested with https://github.com/eslint/eslint/pull/12529