### PR TITLE
Handle there being no parent module

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = moduleId => {
 
 	const parentPath = parentModule(__filename);
 
-	const filePath = resolveFrom(path.dirname(parentPath || moduleId), moduleId);
+	const cwd = parentPath ? path.dirname(parentPath) : __dirname;
+	const filePath = resolveFrom(cwd, moduleId);
 
 	const oldModule = require.cache[filePath];
 	// Delete itself from module parent

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = moduleId => {
 
 	const parentPath = parentModule(__filename);
 
-	const filePath = resolveFrom(path.dirname(parentPath), moduleId);
+	const filePath = resolveFrom(path.dirname(parentPath || moduleId), moduleId);
 
 	const oldModule = require.cache[filePath];
 	// Delete itself from module parent

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ test('import when parent removed from cache', t => {
 	});
 });
 
-test('should not fail when there no parent module', t => {
+test('should not fail when there is no parent module', t => {
 	const targetPath = require.resolve('parent-module');
 	const orignalModule = require.cache[targetPath];
 	delete require.cache[targetPath];

--- a/test.js
+++ b/test.js
@@ -38,3 +38,24 @@ test('import when parent removed from cache', t => {
 		importer(id);
 	});
 });
+
+test('should not fail when there no parent module', t => {
+	const targetPath = require.resolve('parent-module');
+	const orignalModule = require.cache[targetPath];
+	delete require.cache[targetPath];
+	delete require.cache[require.resolve('.')];
+	require.cache[targetPath] = {
+		loaded: true,
+		id: targetPath,
+		exports: () => undefined
+	};
+
+	const id = './fixture-importer';
+	const importer = importFresh(id);
+
+	t.notThrows(() => {
+		importer(id);
+	});
+
+	require.cache[targetPath] = orignalModule;
+});


### PR DESCRIPTION
# Issue when there no parent module 

## Description

As describe here https://github.com/sindresorhus/import-fresh/issues/18 it seems when there no parent module, we have an error. This is typically the case when we bundle with:
- rollup
- ncc
- webpack

In this GitHub Action https://github.com/JulienKode/pull-request-name-linter-action we use import-fresh (actually commitlint/load are using it) and we bundle it with ncc 

As we have a final bundle we do not have parent-module so we have this issue: https://github.com/JulienKode/pull-request-name-linter-action/issues/61

## Testing 

I've added a test case to cover that, I did the module mocking manually. I understand that it's not the best way as some libraries can do that for us.

Fixes #18
Fixes #14