### PR TITLE
Generalize TypeScript declaration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+quote_type = single
 
 [*.yml]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-quote_type = single
 
 [*.yml]
 indent_style = space

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,10 @@ importFresh('./foo')();
 
 importFresh('./foo')();
 //=> 1
+
+const foo = importFresh<typeof import('./foo')>('./foo')
 ```
 */
-declare function importFresh(moduleId: string): unknown;
+declare function importFresh<T>(moduleId: string): T;
 
 export = importFresh;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ importFresh('./foo')();
 importFresh('./foo')();
 //=> 1
 
-const foo = importFresh<typeof import('./foo')>('./foo')
+const foo = importFresh<typeof import('./foo')>('./foo');
 ```
 */
 declare function importFresh<T>(moduleId: string): T;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,12 @@
 import {expectType, expectError} from 'tsd';
 import importFresh = require('.');
+import path = require('path');
 
 expectType<unknown>(importFresh('hello'));
 expectError(importFresh());
+
+expectType<(moduleId: string) => {}>(importFresh<(moduleId: string) => {}>('hello'));
+expectType<path.PlatformPath>(importFresh<path.PlatformPath>('path'));
+
+const foo = importFresh<path.PlatformPath>('path');
+expectType<path.PlatformPath>(foo);


### PR DESCRIPTION
This so we can assign correct signature when importing.

Example:

```ts
import importFresh from "import-fresh";

const path = importFresh<typeof import("path")>("path");
```
