### PR TITLE
Fix tests and bun (#26 #30)

### DIFF
--- a/heapdump.js
+++ b/heapdump.js
@@ -3,13 +3,13 @@ const heapdump = require('heapdump'); // eslint-disable-line import/no-unresolve
 const importFresh = require('.');
 
 for (let i = 0; i < 100000; i++) {
-	require('./fixture.js')();
+	require('./fixture')();
 }
 
 heapdump.writeSnapshot(`require-${Date.now()}.heapsnapshot`);
 
 for (let i = 0; i < 100000; i++) {
-	importFresh('./fixture.js')();
+	importFresh('./fixture')();
 }
 
 heapdump.writeSnapshot(`import-fresh-${Date.now()}.heapsnapshot`);

--- a/index.js
+++ b/index.js
@@ -29,5 +29,6 @@ module.exports = moduleId => {
 
 	const parent = require.cache[parentPath]; // If `filePath` and `parentPath` are the same, cache will already be deleted so we won't get a memory leak in next step
 
-	return parent === undefined ? require(filePath) : parent.require(filePath); // In case cache doesn't have parent, fall back to normal require
+	// In case cache doesn't have parent, fall back to normal require
+	return parent === undefined || parent.require === undefined ? require(filePath) : parent.require(filePath);
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,6 @@
 import {expectType, expectError} from 'tsd';
 import importFresh = require('.');
-import path = require('path');
+import path = require('node:path');
 
 expectType<unknown>(importFresh('hello'));
 expectError(importFresh());

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
 		"bypass"
 	],
 	"dependencies": {
-		"parent-module": "^1.0.0",
-		"resolve-from": "^4.0.0"
+		"parent-module": "^2.0.0",
+		"resolve-from": "^5.0.0"
 	},
 	"devDependencies": {
+		"@types/node": "^22.12.0",
 		"ava": "^1.0.1",
 		"heapdump": "^0.3.12",
-		"tsd": "^0.7.3",
+		"tsd": "^0.31.2",
 		"xo": "^0.23.0"
 	}
 }


### PR DESCRIPTION
As addressed in #26, `parent-module@^3` bumps the `callsites` packages to a new version that fixes a bug encountered when running with bun.

Unfortunately, using `parent-module@^3` in this package would require moving to ESM, which, as discussed in #22, may not be viable right now - hence this manual fix.

This PR would mainly allow running `eslint` with bun (and possibly other blocking runtimes and environments that I may not be aware of).